### PR TITLE
Use GITHUB_SHA in Docker image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Package JAR
       run: mvn clean install
     - name: Build Docker image
-      run: docker build . --tag ssheldharv/dbio-fhir-proxy:${{ steps.vars.outputs.sha_short }} --tag ssheldharv/dbio-fhir-proxy:latest
+      run: docker build . --tag ssheldharv/dbio-fhir-proxy:$GITHUB_SHA --tag ssheldharv/dbio-fhir-proxy:latest
     - name: Push Docker image
       run: docker push --all-tags ssheldharv/dbio-fhir-proxy

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ fabric.properties
 # DS_Store
 .DS_Store
 
+# Git stuff
+.git/
+


### PR DESCRIPTION
Other env var was deprecated https://github.blog/changelog/2021-01-21-github-actions-short-sha-deprecation/