### PR TITLE
Add Auth0 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# security config
+src/main/resources/security/security.properties
+
 ### Java template
 # Compiled class file
 *.class

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.6.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity5</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/dbio/fhirproxy/config/ConfigurationException.java
+++ b/src/main/java/com/dbio/fhirproxy/config/ConfigurationException.java
@@ -1,0 +1,22 @@
+package com.dbio.fhirproxy.config;
+
+public class ConfigurationException extends Exception {
+
+    private String action;
+
+    private String reason;
+
+    public ConfigurationException(String action, String reason) {
+        this.action = action;
+        this.reason = reason;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}
+

--- a/src/main/java/com/dbio/fhirproxy/config/LogoutHandler.java
+++ b/src/main/java/com/dbio/fhirproxy/config/LogoutHandler.java
@@ -1,0 +1,80 @@
+package com.dbio.fhirproxy.config;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Needed to perform SSO logout with Auth0. By default, Spring will clear the SecurityContext and the session.
+ * This controller will also log users out of Auth0 by calling the Auth0 logout endpoint.
+ */
+@Controller
+public class LogoutHandler extends SecurityContextLogoutHandler {
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    /**
+     * Create a new instance with a {@code ClientRegistrationRepository}, so that we can look up information about the
+     * configured provider to call the Auth0 logout endpoint. Called by the Spring framework.
+     *
+     * @param clientRegistrationRepository the {@code ClientRegistrationRepository} for this application.
+     */
+    @Autowired
+    public LogoutHandler(ClientRegistrationRepository clientRegistrationRepository) {
+        this.clientRegistrationRepository = clientRegistrationRepository;
+    }
+
+    /**
+     * Delegates to {@linkplain SecurityContextLogoutHandler} to log the user out of the application, and then logs
+     * the user out of Auth0.
+     *
+     * @param httpServletRequest the request.
+     * @param httpServletResponse the response.
+     * @param authentication the current authentication.
+     */
+    @Override
+    public void logout(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                       Authentication authentication) {
+
+        // Invalidate the session and clear the security context
+        super.logout(httpServletRequest, httpServletResponse, authentication);
+
+        // Build the URL to log the user out of Auth0 and redirect them to the home page.
+        // URL will look like https://YOUR-DOMAIN/v2/logout?clientId=YOUR-CLIENT-ID&returnTo=http://localhost:3000
+        String issuer = (String) getClientRegistration().getProviderDetails().getConfigurationMetadata().get("issuer");
+        String clientId = getClientRegistration().getClientId();
+        String returnTo = ServletUriComponentsBuilder.fromCurrentContextPath().build().toString();
+
+        String logoutUrl = UriComponentsBuilder
+                .fromHttpUrl(issuer + "v2/logout?client_id={clientId}&returnTo={returnTo}")
+                .encode()
+                .buildAndExpand(clientId, returnTo)
+                .toUriString();
+
+        try {
+            httpServletResponse.sendRedirect(logoutUrl);
+        } catch (IOException ioe) {
+            // Handle or log error redirecting to logout URL
+        }
+    }
+
+    /**
+     * Gets the Spring ClientRegistration, which we use to get the registered client ID and issuer for building the
+     * {@code returnTo} query parameter when calling the Auth0 logout API.
+     *
+     * @return the {@code ClientRegistration} for this application.
+     */
+    private ClientRegistration getClientRegistration() {
+        return this.clientRegistrationRepository.findByRegistrationId("auth0");
+    }
+}

--- a/src/main/java/com/dbio/fhirproxy/config/WebSecurityConfig.java
+++ b/src/main/java/com/dbio/fhirproxy/config/WebSecurityConfig.java
@@ -1,0 +1,43 @@
+package com.dbio.fhirproxy.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@PropertySource("classpath:security/security.properties")
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final LogoutHandler logoutHandler;
+
+    private static Logger logger = LoggerFactory.getLogger(WebSecurityConfig.class);
+
+    public WebSecurityConfig(LogoutHandler logoutHandler) {
+        this.logoutHandler = logoutHandler;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws ConfigurationException {
+        try {
+            http
+                .authorizeRequests()
+                .antMatchers("/").authenticated()
+                .and()
+                .oauth2Login()
+                .and()
+                .logout()
+                // handle logout requests at /logout path
+                .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+                // customize logout handler to log out of Auth0
+                .addLogoutHandler(logoutHandler);
+        } catch (Exception e) {
+            logger.error("Error configuring WebSecurityConfig");
+            throw new ConfigurationException("Configuring HttpSecurity", "Issue in WebSecurityConfig configuring HttpSecurity with csrf");
+        }
+    }
+}
+

--- a/src/main/java/com/dbio/fhirproxy/web/controller/AuthenticationController.java
+++ b/src/main/java/com/dbio/fhirproxy/web/controller/AuthenticationController.java
@@ -1,0 +1,21 @@
+package com.dbio.fhirproxy.web.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AuthenticationController {
+
+    @GetMapping("/")
+    public String home(Model model, @AuthenticationPrincipal OidcUser principal) {
+        // Print out principal to console - This will contain ID Token required to initialize IronCore SDK
+        System.out.println(principal);
+        if (principal != null) {
+            model.addAttribute("profile", principal.getClaims());
+        }
+        return "index";
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,12 @@
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity5">
+    <body>
+        <div sec:authorize="!isAuthenticated()">
+            <a th:href="@{/oauth2/authorization/auth0}">Log In</a>
+        </div>
+        <div sec:authorize="isAuthenticated()">
+            <h2 th:text="${profile.get('name')}"></h2>
+            <p th:text="${profile.get('email')}"></p>
+            <a th:href="@{/logout}">Log Out</a>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This PR implements Auth0. This is one option to obtaining a valid ID token JWT to be used for initializing the IronCore SDK. In order to log in you must go to localhost:8080 and log in via google. 

**Note** that for this to work a security.properties file is required that has the configuration values for our Auth0 FHIR proxy application. That has been .gitignored for the sake of security. In order to create it see the example [here](https://auth0.com/docs/quickstart/webapp/java-spring-boot) and get the values from the dBio FHIR Proxy on our Auth0 tenant.