### PR TITLE
Call initialize on server load

### DIFF
--- a/src/main/java/com/dbio/fhirproxy/servlet/FhirRestfulServer.java
+++ b/src/main/java/com/dbio/fhirproxy/servlet/FhirRestfulServer.java
@@ -18,6 +18,11 @@ public class FhirRestfulServer extends RestfulServer {
 
     public FhirRestfulServer(ApplicationContext context) {
         this.applicationContext = context;
+         try {
+             initialize();
+         } catch (Exception e) {
+             System.out.println("Unable to initialize FHIR Proxy");
+         };
     }
 
     @Override


### PR DESCRIPTION
see https://github.com/HES-Capstone-dBio/dbio-fhir-proxy/issues/44

Initialization call was moved to after assignment of application context. You should notice a dramatic change in speed of first call. You can confirm this is happening by looking for the following JNI_onLoad and following logs to appear upon server startup instead of on the first API call.

## How to test
Confirm the following logs appear at startup and not on first API call. Compare the time difference on first API call with fix and without. **Note** you don't need to do anything with the client prior to testing this. Just build the branch locally and change the configuration in the docker-compose.yml inside the dbio-protocol to use the dbio-fhir-proxy/test image instead of the ssheldharv/dbio-fhir-proxy:latest image. See Fhir proxy readme for notes on building locally.

<img width="1083" alt="Screen Shot 2022-05-05 at 10 17 53 AM" src="https://user-images.githubusercontent.com/20730278/166943812-e0f43097-678d-44d7-a947-36dcf2965556.png">

